### PR TITLE
Bug fix: Proper handling of custom tile servers in the OfflineLoader class

### DIFF
--- a/tkintermapview/offline_loading.py
+++ b/tkintermapview/offline_loading.py
@@ -19,6 +19,8 @@ class OfflineLoader:
 
         if tile_server is None:
             self.tile_server = "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        else:
+            self.tile_server = tile_server
 
         self.max_zoom = max_zoom
 


### PR DESCRIPTION
The OfflineLoader class contains a bug: If the optional parameter tile_server is provided, it is not used (which would be expected). Instead, the internal member variable self.tile_server is not set at all in this case, which breaks the functionality of an object constructed this way.
This bug fix fixes that issue.