### PR TITLE
Remove `customtkinter` from build and installation requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-customtkinter~=5.0.3
 requests==2.26.0
 pillow~=9.3.0
 future~=0.18.2

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name="tkintermapview",
       classifiers=["Operating System :: OS Independent",
                    "Programming Language :: Python :: 3",
                    "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication"],
-      install_requires=["geocoder", "pillow", "requests", "pyperclip", 'pywin32; platform_system=="Windows"', "customtkinter"],
+      install_requires=["geocoder", "pillow", "requests", "pyperclip", 'pywin32; platform_system=="Windows"'],
       python_requires=">=3.6")


### PR DESCRIPTION
TkinterMapView does not depend on CustomTkinter, either to build or install it.