### PR TITLE
fix for issue #102: wait for threads to end before destroying mapview…

### DIFF
--- a/tkintermapview/map_widget.py
+++ b/tkintermapview/map_widget.py
@@ -163,6 +163,9 @@ class TkinterMapView(tkinter.Frame):
 
     def destroy(self):
         self.running = False
+        self.pre_cache_thread.join()
+        for thread in self.image_load_thread_pool:
+            thread.join()
         super().destroy()
 
     def draw_rounded_corners(self):


### PR DESCRIPTION
When we allow all threads to cleanly shutdown before the mapview widget is destroyed, issue #102, the fatal in a thread when closing the mapview window, disappears.