### PR TITLE
bug: Fixed Image.ANTIALIAS no longer existing in Python PIL

### DIFF
--- a/tkintermapview/map_widget.py
+++ b/tkintermapview/map_widget.py
@@ -502,7 +502,7 @@ class TkinterMapView(tkinter.Frame):
                 image_overlay = image_overlay.convert("RGBA")
 
                 if image_overlay.size is not (self.tile_size, self.tile_size):
-                    image_overlay = image_overlay.resize((self.tile_size, self.tile_size), Image.ANTIALIAS)
+                    image_overlay = image_overlay.resize((self.tile_size, self.tile_size), Image.LANCZOS)
 
                 image.paste(image_overlay, (0, 0), image_overlay)
 


### PR DESCRIPTION
In map_widget.py, on Line 505, The `Image.ANTIALIAS` parameter used in resize no longer exists within the PIL library causing the map to just draw blank when using a map overlay.

https://stackoverflow.com/questions/23113163/antialias-vs-bicubic-in-pilpython-image-library

Needs to be replaced by `Image.LANCZOS` as this is the direct replacement of `Image.ANTIALIAS`