### PR TITLE
Add set_visibility and show_zoom_buttons

### DIFF
--- a/tkintermapview/canvas_button.py
+++ b/tkintermapview/canvas_button.py
@@ -74,3 +74,11 @@ class CanvasButton:
         self.map_widget.canvas.tag_bind(self.canvas_text, "<Enter>", self.hover_on)
         self.map_widget.canvas.tag_bind(self.canvas_rect, "<Leave>", self.hover_off)
         self.map_widget.canvas.tag_bind(self.canvas_text, "<Leave>", self.hover_off)
+
+    def set_visibility(self, visible: bool):
+        if visible:
+            self.map_widget.canvas.itemconfigure(self.canvas_rect, state="normal")
+            self.map_widget.canvas.itemconfigure(self.canvas_text, state="normal")
+        else:
+            self.map_widget.canvas.itemconfigure(self.canvas_rect, state="hidden")
+            self.map_widget.canvas.itemconfigure(self.canvas_text, state="hidden")

--- a/tkintermapview/map_widget.py
+++ b/tkintermapview/map_widget.py
@@ -927,3 +927,7 @@ class TkinterMapView(tkinter.Frame):
     def button_zoom_out(self):
         # zoom out of middle of map
         self.set_zoom(self.zoom - 1, relative_pointer_x=0.5, relative_pointer_y=0.5)
+
+    def show_zoom_buttons(self, show: bool = True):
+        self.button_zoom_in.set_visibility(show)
+        self.button_zoom_out.set_visibility(show)


### PR DESCRIPTION
feat: Add functionality to toggle visibility of zoom buttons

Response to Issue #147 
https://github.com/TomSchimansky/TkinterMapView/issues/147 

- Introduced `set_visibility` method in `CanvasButton` to dynamically show or hide buttons by controlling their canvas item states.
- Added `toggle_zoom_buttons` method in `TkinterMapView` to manage the visibility of zoom buttons (`+` and `-`) using the new `set_visibility` feature.
- Ensures clean UI manipulation by hiding buttons when not needed, while preserving functionality for future re-enabling.

This update enhances the flexibility of the map widget interface.